### PR TITLE
Decode electrum error response

### DIFF
--- a/electrumrpc.go
+++ b/electrumrpc.go
@@ -50,7 +50,15 @@ func (c *Client) Call(method string, params interface{}, result interface{}) err
 
 	defer resp.Body.Close()
 
-	return json.DecodeClientResponse(resp.Body, result)
+	var error RequestError
+	err = json.DecodeClientResponse(resp.Body, result, &error)
+	if err != nil {
+		return err
+	}
+	if error.Id != 0 {
+		return &error
+	}
+	return nil
 }
 
 // newRequest creates new HTTP POST request with Basic Auth headers

--- a/models.go
+++ b/models.go
@@ -14,6 +14,15 @@ const (
 	FeeMethodMempool FeeMethod = "mempool"
 )
 
+type RequestError struct {
+	Id      uint64 `json:"code"`
+	Message string `json:"message"`
+}
+
+func (r *RequestError) Error() string {
+	return r.Message
+}
+
 // Balance model
 type Balance struct {
 	Confirmed   string `json:"confirmed"`


### PR DESCRIPTION
Electrum response the error a json object with code and message fields: https://github.com/spesmilo/electrum/blob/62e1d8ed78635ca6566078583c11933581c0212b/electrum/daemon.py#L232-L235

If there is an error response from electrum (with MarinX/rpc#1), the decoded custom error object is returned.
Can be used any error function same as standard golang error object.